### PR TITLE
Refactored vhost script and README.md added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,88 @@
+# Apache Virtual Host Creation Script
+
+This Bash script helps you quickly set up a new Apache virtual host on a Debian-based system (e.g., Ubuntu). It interactively prompts you for the domain name, document root, and email address (optional), then creates the configuration file, updates `/etc/hosts`, and reloads Apache.
+
+---
+
+## 🛠 Features
+
+- Interactive input (no arguments required)
+- Automatically creates document root if it doesn't exist
+- Adds entry to `/etc/hosts`
+- Uses `a2ensite` to enable the vhost
+- Reloads Apache server
+
+---
+
+## 📋 Requirements
+
+- Apache installed (`apache2`)
+- Root privileges (to write to system directories and restart Apache)
+
+---
+
+## 🚀 How to Use
+
+1. **Make the script executable** (if it’s not already):
+
+   ```bash
+   chmod +x vhost-create.sh
+   ```
+
+2. **Run the script with sudo**:
+
+   ```bash
+   sudo ./vh.sh
+   ```
+
+3. **Follow the prompts**:
+
+   - Domain name (e.g., `example.local`)
+   - Web root directory (e.g., `/var/www/example`)
+   - ServerAdmin email (optional, default is `webmaster@localhost`)
+
+4. **Open your browser** and visit:
+
+   ```
+   http://your-domain-name
+   ```
+
+   For example: `http://example.local`
+
+---
+
+## 📁 Sample Web Root Directory Structure
+
+```
+/var/www/example
+├── index.html
+```
+
+Create an `index.html` file in the directory to test your virtual host.
+
+---
+
+## ⚠️ Notes
+
+- This script is designed for local development environments.
+- For live/production servers, consider adding SSL support using Let's Encrypt or self-signed certificates.
+
+---
+
+## 🧹 Undo / Remove a Virtual Host
+
+If you want to disable or remove a virtual host:
+
+```bash
+sudo a2dissite your-domain.conf
+sudo rm /etc/apache2/sites-available/your-domain.conf
+sudo systemctl reload apache2
+```
+
+Also remove the entry from `/etc/hosts` if needed.
+
+---
+
+## 📝 License
+
+This script is free to use, modify, and distribute.

--- a/vh.sh
+++ b/vh.sh
@@ -1,30 +1,66 @@
 #!/bin/bash
+set -e
 
-name=$1
-WEB_ROOT_DIR=$2
+# Prompt for domain name
+read -p "Enter the domain name (e.g., example.com): " name
+if [[ -z "$name" ]]; then
+  echo "Domain name cannot be empty."
+  exit 1
+fi
 
-email=${3-'webmaster@localhost'}
-sitesEnable='/etc/apache2/sites-enabled/'
-sitesAvailable='/etc/apache2/sites-available/'
-sitesAvailabledomain=$sitesAvailable$name.conf
-echo "Creating a vhost for $sitesAvailabledomain with a webroot $WEB_ROOT_DIR"
+# Prompt for web root directory
+read -p "Enter the web root directory (e.g., /var/www/example): " WEB_ROOT_DIR
+if [[ -z "$WEB_ROOT_DIR" ]]; then
+  echo "Web root directory cannot be empty."
+  exit 1
+fi
 
-### create virtual host rules file
-echo "
-    <VirtualHost *:80>
-      ServerAdmin $email
-      ServerName $name
-      DocumentRoot $WEB_ROOT_DIR
-      <Directory $WEB_ROOT_DIR/>
+# Prompt for email with default
+read -p "Enter ServerAdmin email [webmaster@localhost]: " email
+email=${email:-webmaster@localhost}
+
+sitesAvailable='/etc/apache2/sites-available'
+vhostFile="$sitesAvailable/$name.conf"
+
+echo "Creating a virtual host for $name with web root $WEB_ROOT_DIR"
+
+# Create the document root directory if it doesn't exist
+if [ ! -d "$WEB_ROOT_DIR" ]; then
+  echo "Creating web root directory at $WEB_ROOT_DIR"
+  mkdir -p "$WEB_ROOT_DIR"
+  chown -R www-data:www-data "$WEB_ROOT_DIR"
+  chmod -R 755 "$WEB_ROOT_DIR"
+fi
+
+# Create the virtual host configuration
+cat <<EOF > "$vhostFile"
+<VirtualHost *:80>
+    ServerAdmin $email
+    ServerName $name
+    ServerAlias www.$name
+    DocumentRoot $WEB_ROOT_DIR
+
+    <Directory $WEB_ROOT_DIR>
         Options Indexes FollowSymLinks
-        AllowOverride all
-      </Directory>
-    </VirtualHost>" > $sitesAvailabledomain
-echo -e $"\nNew Virtual Host Created\n"
+        AllowOverride All
+        Require all granted
+    </Directory>
 
-sed -i "1s/^/127.0.0.1 $name\n/" /etc/hosts
+    ErrorLog \${APACHE_LOG_DIR}/$name-error.log
+    CustomLog \${APACHE_LOG_DIR}/$name-access.log combined
+</VirtualHost>
+EOF
 
-a2ensite $name
-service apache2 reload
+echo "Virtual host file created at $vhostFile"
 
-echo "Done, please browse to http://$name to check!"
+# Add domain to /etc/hosts if not already present
+if ! grep -q "$name" /etc/hosts; then
+  echo "127.0.0.1 $name" >> /etc/hosts
+  echo "Added $name to /etc/hosts"
+fi
+
+# Enable the site and reload Apache
+a2ensite "$name.conf"
+systemctl reload apache2
+
+echo "Done. Visit http://$name in your browser."


### PR DESCRIPTION
Refactor vhost script: prompt for inputs interactively and remove unused sitesEnabled variable

- Replaced positional arguments with interactive `read -p` prompts for domain, web root, and optional email.
- Improved input validation for domain name and web root.
- Removed unused `sitesEnabled` variable since `a2ensite` handles symlinks automatically.
- Retained best practices including `set -e` and proper virtual host formatting.
- README.md file added.